### PR TITLE
Added ReplaceMultipleAddCommand command to add multiple packages

### DIFF
--- a/src/Composer/Command/ReplaceMultipleAddCommand.php
+++ b/src/Composer/Command/ReplaceMultipleAddCommand.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Yireo\ReplaceTools\Composer\Command;
+
+use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yireo\ReplaceTools\Composer\Model\Replacement;
+use Yireo\ReplaceTools\Composer\Service\ReplaceBuilder;
+
+class ReplaceMultipleAddCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        $this->setName('replace:multiple:add');
+        $this->setDescription('Replace multiple composer packages');
+        $this->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'Packages to replace (separate multiple packages with a space)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $packages = $input->getArgument('packages');
+
+        foreach ($packages as $package) {
+            $replaceBuilder = new ReplaceBuilder();
+            $replaceBuilder->replace($package, '*');
+            $replaceBuilder->addInclude(new Replacement($package));
+
+            $output->writeln('Added composer replacement for ' . $package);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Composer/CommandProvider.php
+++ b/src/Composer/CommandProvider.php
@@ -14,6 +14,7 @@ use Yireo\ReplaceTools\Composer\Command\ReplaceIncludeCommand;
 use Yireo\ReplaceTools\Composer\Command\ReplaceListCommand;
 use Yireo\ReplaceTools\Composer\Command\ReplaceRemoveCommand;
 use Yireo\ReplaceTools\Composer\Command\ReplaceValidateCommand;
+use Yireo\ReplaceTools\Composer\Command\ReplaceMultipleAddCommand;
 
 class CommandProvider implements CommandProviderCapability
 {
@@ -31,6 +32,7 @@ class CommandProvider implements CommandProviderCapability
             new ReplaceBulkListCommand(),
             new ReplaceValidateCommand(),
             new ReplaceBuildCommand(),
+            new ReplaceMultipleAddCommand(),
         ];
     }
 }


### PR DESCRIPTION
Added a command to add multiple packages in one command, for example:

```
composer replace:multiple:add magento/module-ups \
            magento/module-usps \
            magento/module-worldpay \
            magento/module-authorizenet \
            magento/module-authorizenet-acceptjs \
            magento/module-authorizenet-cardinal \
            magento/module-authorizenet-graph-ql \
            magento/module-eway \
            magento/module-dhl \
            magento/module-cybersource \
            magento/module-new-relic-reporting \
            magento/module-page-builder-admin-analytics \
            magento/module-page-builder-analytics \
            magento/module-version \
            magento/module-marketplace \
            astock/stock-api-libphp \
            magento/adobe-stock-integration \
            magento/module-admin-adobe-ims \
            magento/module-admin-adobe-ims-two-factor-auth \
            magento/module-admin-analytics \
            magento/module-adobe-ims \
            magento/module-adobe-ims-api \
            magento/module-adobe-stock-admin-ui \
            magento/module-adobe-stock-asset \
            magento/module-adobe-stock-asset-api \
            magento/module-adobe-stock-client \
            magento/module-adobe-stock-client-api \
            magento/module-adobe-stock-image \
            magento/module-adobe-stock-image-admin-ui \
            magento/module-adobe-stock-image-api \
            magento/module-weee \
            magento/module-weee-graph-ql \
            magento/module-saas-common \
            magento/module-paypal \
            magento/module-paypal-captcha \
            magento/module-paypal-graph-ql \
            paypal/module-braintree-customer-balance \
            paypal/module-braintree-gift-card-account \
            paypal/module-braintree-gift-wrapping
```

This returns the following:
```
Added composer replacement for magento/module-ups
Added composer replacement for magento/module-usps
Added composer replacement for magento/module-worldpay
Added composer replacement for magento/module-authorizenet
Added composer replacement for magento/module-authorizenet-acceptjs
Added composer replacement for magento/module-authorizenet-cardinal
Added composer replacement for magento/module-authorizenet-graph-ql
Added composer replacement for magento/module-eway
Added composer replacement for magento/module-dhl
Added composer replacement for magento/module-cybersource
Added composer replacement for magento/module-new-relic-reporting
Added composer replacement for magento/module-page-builder-admin-analytics
Added composer replacement for magento/module-page-builder-analytics
Added composer replacement for magento/module-version
Added composer replacement for magento/module-marketplace
Added composer replacement for astock/stock-api-libphp
Added composer replacement for magento/adobe-stock-integration
Added composer replacement for magento/module-admin-adobe-ims
Added composer replacement for magento/module-admin-adobe-ims-two-factor-auth
Added composer replacement for magento/module-admin-analytics
Added composer replacement for magento/module-adobe-ims
Added composer replacement for magento/module-adobe-ims-api
Added composer replacement for magento/module-adobe-stock-admin-ui
Added composer replacement for magento/module-adobe-stock-asset
Added composer replacement for magento/module-adobe-stock-asset-api
Added composer replacement for magento/module-adobe-stock-client
Added composer replacement for magento/module-adobe-stock-client-api
Added composer replacement for magento/module-adobe-stock-image
Added composer replacement for magento/module-adobe-stock-image-admin-ui
Added composer replacement for magento/module-adobe-stock-image-api
Added composer replacement for magento/module-weee
Added composer replacement for magento/module-weee-graph-ql
Added composer replacement for magento/module-saas-common
Added composer replacement for magento/module-paypal
Added composer replacement for magento/module-paypal-captcha
Added composer replacement for magento/module-paypal-graph-ql
Added composer replacement for paypal/module-braintree-customer-balance
Added composer replacement for paypal/module-braintree-gift-card-account
Added composer replacement for paypal/module-braintree-gift-wrapping
```